### PR TITLE
fix a small bug in cascade_forest()

### DIFF
--- a/GCForest.py
+++ b/GCForest.py
@@ -351,6 +351,9 @@ class gcForest(object):
             self.n_layer += 1
             prf_crf_pred_layer = self._cascade_layer(feat_arr, y_train)
             accuracy_layer = self._cascade_evaluation(X_test, y_test)
+            
+            if accuracy_layer <= (accuracy_ref + tol):
+                self.n_layer -= 1
 
             while accuracy_layer > (accuracy_ref + tol) and self.n_layer <= max_layers:
                 accuracy_ref = accuracy_layer


### PR DESCRIPTION
It is possible that the performance(acc in this implementation) of the gcForest gets worse just after adding the second layer(I have actuall met this situation), so we have to minus `n_layer`. Otherwise the prediction is not what we want.